### PR TITLE
fix: remove hardcoded API URL, use environment variables

### DIFF
--- a/alco-shop-frontend/src/components/CardMenu.tsx
+++ b/alco-shop-frontend/src/components/CardMenu.tsx
@@ -4,6 +4,8 @@ import { increment, decrement, removeItem } from '../store/itemSlice';
 import { selectTotalPrice } from '../store/itemSlice';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
+import { getImageUrl } from '../utils/getImageUrl';
+
 
 interface CartProps {
   isOpen: boolean;
@@ -43,7 +45,7 @@ function Cart({ isOpen, onClose }: CartProps) {
           {itemCard.map((item) => (
             <div key={item.ProductId} className="flex gap-4 pb-4 border-b">
               <img
-                src={`http://localhost:5000/images/${item.ImagePath}`}
+                src={getImageUrl(item.ImagePath)}
                 alt={item.Name}
                 className="w-20 h-20 object-cover rounded"
               />

--- a/alco-shop-frontend/src/components/CategoriesList.tsx
+++ b/alco-shop-frontend/src/components/CategoriesList.tsx
@@ -12,6 +12,7 @@ import { addItem } from '../store/itemSlice';
 import { likeItems } from '../store/wishListSlice';
 import { toast } from 'react-toastify';
 import { ROLES } from '../utils/roles';
+import { getImageUrl } from '../utils/getImageUrl';
 
 function CategoriesList() {
   const dispatch = useDispatch<AppDispatch>();
@@ -199,7 +200,7 @@ function CategoriesList() {
                       >
                         {product.ImagePath ? (
                           <img
-                            src={`http://localhost:5000/images/${product.ImagePath}`}
+                              src={getImageUrl(product.ImagePath)}
                             alt={product.Name}
                             className="w-full h-full object-cover group-hover:scale-110 transition duration-300"
                           />

--- a/alco-shop-frontend/src/components/CategoryProducts.tsx
+++ b/alco-shop-frontend/src/components/CategoryProducts.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import ProductService from '../service/product/ProductService';
 import { ICategoryProducts } from '../models/category/ICategoryProducts';
+import { getImageUrl } from '../utils/getImageUrl';
 
 function CategoryProducts() {
   const { categoryName } = useParams<{ categoryName: string }>();
@@ -61,7 +62,7 @@ function CategoryProducts() {
                   >
                     {product.ImagePath && (
                       <img
-                        src={`http://localhost:5000/images/${product.ImagePath}`}
+                        src={getImageUrl(product.ImagePath)}
                         alt={product.Name}
                         className="w-full h-48 object-contain block"
                       />

--- a/alco-shop-frontend/src/components/ProductDetail.tsx
+++ b/alco-shop-frontend/src/components/ProductDetail.tsx
@@ -10,6 +10,7 @@ import ReviewService from '../service/review/ReviewService';
 import { IGetReview } from '../models/review/IGetReview';
 import { likeItems } from '../store/wishListSlice';
 import { toast } from 'react-toastify';
+import { getImageUrl } from '../utils/getImageUrl';
 
 function ProductDetail() {
   const { productId } = useParams<{ productId: string }>();
@@ -161,7 +162,7 @@ function ProductDetail() {
               <div className="w-full h-96 bg-gray-200 rounded-lg mb-6 flex items-center justify-center overflow-hidden">
                 {product.ImagePath ? (
                   <img
-                    src={`http://localhost:5000/images/${product.ImagePath}`}
+                    src={getImageUrl(product.ImagePath)}
                     alt={product.Name}
                     className="w-full h-full object-cover"
                   />

--- a/alco-shop-frontend/src/components/WishList.tsx
+++ b/alco-shop-frontend/src/components/WishList.tsx
@@ -6,6 +6,7 @@ import { removeLikeItem } from '../store/wishListSlice';
 import { useState } from 'react';
 import Cart from './CardMenu';
 import { toast } from 'react-toastify';
+import { getImageUrl } from '../utils/getImageUrl';
 
 function WishList() {
   const navigate = useNavigate();
@@ -74,7 +75,7 @@ function WishList() {
                 <div className="relative bg-gray-100 h-80 flex items-center justify-center overflow-hidden cursor-pointer group/image w-full">
                   <img
                     onClick={() => navigate(`/product/${item.ProductId}`)}
-                    src={`http://localhost:5000/images/${item.ImagePath}`}
+                    src={getImageUrl(item.ImagePath)}
                     alt={item.Name}
                     className="w-full h-full object-cover group-hover:scale-110 transition duration-300"
                   />

--- a/alco-shop-frontend/src/components/СardMenuOrder.tsx
+++ b/alco-shop-frontend/src/components/СardMenuOrder.tsx
@@ -7,6 +7,7 @@ import { selectTotalPrice } from '../store/itemSlice';
 import { selectTotalPriceDeliver } from '../store/itemSlice';
 import OrderService from '../service/order/OrderSrevice';
 import UpdateUserInfoService from '../service/user/UpdateUserInfoServise';
+import { getImageUrl } from '../utils/getImageUrl';
 
 import { toast } from 'react-toastify';
 
@@ -252,7 +253,7 @@ function CardMenuOrder() {
             {itemCard.map((item) => (
               <div key={item.ProductId} className="flex gap-4 pb-4 border-b">
                 <img
-                  src={`http://localhost:5000/images/${item.ImagePath}`}
+                  src={getImageUrl(item.ImagePath)}
                   alt={item.Name}
                   className="w-20 h-20 object-cover rounded"
                 />

--- a/alco-shop-frontend/src/utils/getImageUrl.ts
+++ b/alco-shop-frontend/src/utils/getImageUrl.ts
@@ -1,0 +1,4 @@
+export const getImageUrl = (imagePath: string): string => {
+  const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000';
+  return `${API_URL}/images/${imagePath}`;
+};


### PR DESCRIPTION
Closes #6 

## Changes
- Created `.env` file with `VITE_API_URL`
- Created `getImageUrl` utility function in `src/utils/getImageUrl.ts`
- Replaced all hardcoded `http://localhost:5000` URLs with `getImageUrl()` helper

## Files Changed
- `src/components/CardMenu.tsx`
- `src/components/CategoriesList.tsx`
- `src/components/CategoryProducts.tsx`
- `src/components/ProductDetail.tsx`
- `src/components/WishList.tsx`
- `src/components/СardMenuOrder.tsx`
- `src/utils/getImageUrl.ts` (new file)